### PR TITLE
Provide mechanism for detecting if redis_retriever is already defined

### DIFF
--- a/lib/radar_client_rb/client.rb
+++ b/lib/radar_client_rb/client.rb
@@ -4,6 +4,10 @@ module Radar
   class Client
     attr_accessor :subdomain
 
+    def self.redis_retriever_defined?
+      defined?(@@redis_retriever) && @@redis_retriever
+    end
+
     def self.define_redis_retriever(&blk)
       @@redis_retriever = blk
     end
@@ -25,7 +29,7 @@ module Radar
     end
 
     def redis
-      @@redis_retriever.call(@subdomain) if defined?(@@redis_retriever) && @@redis_retriever
+      @@redis_retriever.call(@subdomain) if Client.redis_retriever_defined?
     end
   end
 end


### PR DESCRIPTION
We don't want ZAM or voice overriding the redis_retriever block from classic.

@zendesk/zendesk-radar 
