### PR TITLE
log after write, so client is connected for sure

### DIFF
--- a/lib/radar_client_rb/resource.rb
+++ b/lib/radar_client_rb/resource.rb
@@ -48,10 +48,10 @@ module Radar
         client_info = "Client: #{@client.redis.client.host}:#{@client.redis.client.port}"
       end
 
-      logger.info "Setting Status: #{key}, #{value}, #{client_info}"
       @client.redis.hset(@name, key, value.to_json)
       @client.redis.expire(@name, 12*60*60)
       @client.redis.publish(@name, { :to => @name, :op => 'set', :key => key, :value => value }.to_json)
+      logger.info "Set Status: #{key}, #{value}, #{client_info}"
     end
   end
 


### PR DESCRIPTION
@samshull Small change, but makes sure the sentinel connection is actually made. (So no default client_info to confuse us.)
