### PR TITLE
message.at is no longer used

### DIFF
--- a/lib/radar_client_rb/resource.rb
+++ b/lib/radar_client_rb/resource.rb
@@ -19,11 +19,10 @@ module Radar
 
     def get
       result = {}
-      forty_five_seconds_ago = (Time.now.to_i - 45) * 1000
       @client.redis.hgetall(@name).each do |key, value|
         user_id, client_id = key.split('.')
         message = JSON.parse(value)
-        if message['online'] && message['at'] > forty_five_seconds_ago
+        if message['online']
           result[user_id] ||= { :clients => {}, :userType => message['userType'] }
           result[user_id][:clients][client_id] = message['userData'] || {}
         end


### PR DESCRIPTION
During presence rewrite, we deprecated message.at which provides a rudimentary way of clearing out presences for which servers died. We replaced it with a sentry system. However, we missed removing this bit of code.

This is partially correct, and can cause an occasional false positive. (Presence online while no one is online). This can only happen when a server dies and no server picks up this presence resource. (Which is ultrarare). I will fix it with sentry awareness when we do API. But for now, this should fix the problems.

/cc @zendesk/zendesk-radar
### Steps to merge
- [ ] :+1: of the team
### References
- https://github.com/zendesk/zendesk_radar_client_rb/pull/9
### Risks
- Low; False positive presence online. 
