### PR TITLE
privatize gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 PATH
   remote: .
   specs:
-    radar_client_rb (0.1.8)
+    radar_client_rb (0.1.7)
       redis
 
 GEM
   remote: https://rubygems.org/
   specs:
+    bump (0.5.1)
     fakeredis (0.4.2)
       redis (~> 3.0.0)
     metaclass (0.0.1)
@@ -22,6 +23,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bump
   fakeredis
   minitest
   mocha

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler/setup'
-require "private_gem/tasks"
+require 'bump/tasks'
+require 'private_gem/tasks'
 
 task :default => [:test]
 

--- a/lib/radar_client_rb/version.rb
+++ b/lib/radar_client_rb/version.rb
@@ -1,5 +1,5 @@
 module Radar
   class Client
-    VERSION = '0.1.8'
+    VERSION = '0.1.7'
   end
 end

--- a/radar_client_rb.gemspec
+++ b/radar_client_rb.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new "radar_client_rb", Radar::Client::VERSION do |gem|
   gem.add_development_dependency("fakeredis")
   gem.add_development_dependency("mocha")
   gem.add_development_dependency("private_gem")
+  gem.add_development_dependency("bump")
 end


### PR DESCRIPTION
:warning: 

Two problems I noticed, which is new:

when bundling:

```
Warning: the gem 'private_gem' was found in multiple sources.
Installed from: https://rubygems.org/
Also found in:
  * https://gem.zdsys.com/gems/
You should add a source requirement to restrict this gem to your preferred source.
For example:
    gem 'private_gem', :source => 'https://rubygems.org/'
```

after bundling: (THIS IS FIXED, please ignore)

```
[vanchi@MBP] ~/harmony/code/zendesk_redis_factory (master)[0]
-$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

    .bundle/
    vendor/

nothing added to commit but untracked files present (use "git add" to track)
```

/cc @zendesk/zendesk-radar @staugaard @grosser 
### Steps to merge
- [ ] :+1: of the team
### References
- Jira link: https://zendesk.atlassian.net/browse/RADAR-444
### Risks
- None, at this point.
