### PR TITLE
Filters out presence messages from offline sentries.

### DIFF
--- a/lib/radar_client_rb/resource.rb
+++ b/lib/radar_client_rb/resource.rb
@@ -19,27 +19,34 @@ module Radar
 
     def get
       result = {}
-      @client.redis.hgetall(@name).each do |key, value|
-        user_id, client_id = key.split('.')
-        message = JSON.parse(value)
-        if message['online'] && is_sentry_online?(message['sentry'])
-          result[user_id] ||= { :clients => {}, :userType => message['userType'] }
-          result[user_id][:clients][client_id] = message['userData'] || {}
-        end
+
+      clients = get_clients.select { |client| client['online'] }
+      sentries = clients.map { |client| client['sentry'] }
+      online_sentries = select_online_sentries(sentries)
+      online_clients = clients.select { |client| online_sentries.include?(client['sentry']) }
+
+      online_clients.each do |client|
+        user_id = client['userId']
+        result[user_id] ||= { :clients => {}, :userType => client['userType'] }
+        result[user_id][:clients][client['clientId']] = client['userData'] || {}
       end
       result
     end
 
     private
 
-    def sentries
-      @sentries ||= @client.redis.hgetall('sentry:/radar')
+    def get_clients
+      @client.redis.hgetall(@name).values.map { |value| JSON.parse(value) }
     end
 
-    def is_sentry_online?(sentry)
-      return true unless sentry
+    def select_online_sentries(sentry_ids)
+      return [] unless sentry_ids && sentry_ids.any?
+      online_sentries = @client.redis.hmget('sentry:/radar', *sentry_ids.uniq)
+        .select { |x| !x.nil? }
+        .map { |data| JSON.parse(data) }
+        .select { |sentry| !message_is_expired?(sentry) }
 
-      sentries.include?(sentry) && !message_is_expired?(JSON.parse(sentries[sentry]))
+      online_sentries.map { |sentry| sentry['name'] }
     end
 
     def message_is_expired?(message)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -72,7 +72,8 @@ describe Radar::Client do
         :userData => 'userData3',
         :clientId => client_id3,
         :online => true,
-        :at => Time.now.to_i * 1000
+        :at => Time.now.to_i * 1000,
+        :sentry => sentry_id1
       }
     end
     let(:presence4) do
@@ -167,7 +168,7 @@ describe Radar::Client do
     end
 
     it 'does not crash if the key does not exist' do
-      assert_equal client.presence('inexistant').get, {}
+      assert_equal client.presence('nonexistant').get, {}
     end
   end
 
@@ -212,8 +213,8 @@ describe Radar::Client do
       )
       assert_equal client.message(scope).get, [[message1, 123], [message2, 124]]
     end
-    it 'does not crash on inexistant keys' do
-      assert_equal client.message('inexistant').get, []
+    it 'does not crash on nonexistant keys' do
+      assert_equal client.message('nonexistant').get, []
     end
   end
 end


### PR DESCRIPTION
@zendesk/radar, I'm looking into https://support.zendesk.com/agent/tickets/1385217 and I noticed that we aren't filtering out presence messages from down sentries. This PR attempts to handle that.

## Risks
- Low: false positives may occur - online clients may appear offline if there are other data integrity issues with how radar sentries are handled (opposite of current problem: offline clients are appearing online)