### PR TITLE
Add semver range to redis dependency in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     radar_client_rb (1.0.3)
-      redis
+      redis (>= 3, < 3.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -17,7 +17,7 @@ GEM
     private_gem (1.1.0)
       bundler (~> 1.7)
     rake (10.1.0)
-    redis (3.0.5)
+    redis (3.0.7)
 
 PLATFORMS
   ruby
@@ -30,3 +30,6 @@ DEPENDENCIES
   private_gem
   radar_client_rb!
   rake
+
+BUNDLED WITH
+   1.11.2

--- a/radar_client_rb.gemspec
+++ b/radar_client_rb.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new "radar_client_rb", Radar::Client::VERSION do |gem|
   gem.summary = gem.description = "Read/Write Radar Resources from Redis through Ruby"
   gem.files = Dir.glob("lib/**/*")
 
-  gem.add_runtime_dependency("redis")
+  gem.add_runtime_dependency("redis", ">= 3", "< 3.2.1")
 
   gem.add_development_dependency("rake")
   gem.add_development_dependency("minitest")


### PR DESCRIPTION
Certain changes to how redis sentinel is handled in the redis_rb gem after 3.2.0
break tests. This PR adds a range restriction to specify that radar_client_rb
may not work properly with newer versions.

Future versions of radar_client_rb will remove the redis dependency in favor of
the radar service interface.

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None