### PR TITLE
relax the redis version restrictions, set ruby reqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
 rvm:
+  - 2.2
   - 2.3
   - 2.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.1
-  - 2.2
+  - 2.3
+  - 2.4
 
 cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ PATH
   remote: .
   specs:
     radar_client_rb (2.0.1)
-      redis (>= 3, < 3.2.1)
+      redis (~> 3.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
     bump (0.5.1)
-    fakeredis (0.4.2)
-      redis (~> 3.0.0)
+    fakeredis (0.7.0)
+      redis (>= 3.2, < 5.0)
     metaclass (0.0.1)
     minitest (5.0.8)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     rake (10.1.0)
-    redis (3.0.7)
+    redis (3.3.5)
 
 PLATFORMS
   ruby
@@ -29,4 +29,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.11.2
+   1.16.2

--- a/radar_client_rb.gemspec
+++ b/radar_client_rb.gemspec
@@ -7,7 +7,9 @@ Gem::Specification.new "radar_client_rb", Radar::Client::VERSION do |gem|
   gem.summary = gem.description = "Read/Write Radar Resources from Redis through Ruby"
   gem.files = Dir.glob("lib/**/*")
 
-  gem.add_runtime_dependency("redis", ">= 3", "< 3.2.1")
+  gem.required_ruby_version = ["~> 2.3", ">= 2.3"]
+
+  gem.add_runtime_dependency("redis", "~> 3.3")
 
   gem.add_development_dependency("rake")
   gem.add_development_dependency("minitest")

--- a/radar_client_rb.gemspec
+++ b/radar_client_rb.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new "radar_client_rb", Radar::Client::VERSION do |gem|
   gem.summary = gem.description = "Read/Write Radar Resources from Redis through Ruby"
   gem.files = Dir.glob("lib/**/*")
 
-  gem.required_ruby_version = ["~> 2.3", ">= 2.3"]
+  gem.required_ruby_version = ["~> 2.2", ">= 2.2"]
 
   gem.add_runtime_dependency("redis", "~> 3.3")
 


### PR DESCRIPTION
This relaxes the redis version requirements to allow newer minor versions of redis. This also sets ruby version requirements to be on Ruby 2.3 or newer. 

#17 talked about problems with redis-sentinel and newer versions of redis, but I don't see any code in here that cares about sentinel or not and the tests all seemed to pass locally. 

/cc @zendesk/support-platform @zendesk/radar @vanchi-zendesk 