### PR TITLE
[CCORE-122] bump dependencies and use new Redis#connection that was i…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,18 @@ PATH
   remote: .
   specs:
     radar_client_rb (2.1.0)
-      redis (~> 3.3)
+      redis (~> 4.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    bump (0.5.1)
-    fakeredis (0.7.0)
-      redis (>= 3.2, < 5.0)
-    metaclass (0.0.1)
-    minitest (5.0.8)
-    mocha (0.14.0)
-      metaclass (~> 0.0.1)
-    rake (10.1.0)
-    redis (3.3.5)
+    bump (0.10.0)
+    fakeredis (0.8.0)
+      redis (~> 4.1)
+    minitest (5.14.4)
+    mocha (1.13.0)
+    rake (13.0.6)
+    redis (4.3.1)
 
 PLATFORMS
   ruby
@@ -29,4 +27,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/lib/radar_client_rb/resource.rb
+++ b/lib/radar_client_rb/resource.rb
@@ -72,7 +72,7 @@ module Radar
         redis.publish(@name, { :to => @name, :op => 'set', :key => key, :value => value }.to_json)
       end
 
-      client = redis.respond_to?(:client) && redis.connection
+      client = redis.respond_to?(:connection) && redis.connection
       client_info = if client && client.respond_to?(:host) && client.respond_to?(:port)
         "Client: #{client.host}:#{client.port}"
       else

--- a/lib/radar_client_rb/resource.rb
+++ b/lib/radar_client_rb/resource.rb
@@ -72,7 +72,7 @@ module Radar
         redis.publish(@name, { :to => @name, :op => 'set', :key => key, :value => value }.to_json)
       end
 
-      client = redis.respond_to?(:client) && redis.client
+      client = redis.respond_to?(:client) && redis.connection
       client_info = if client && client.respond_to?(:host) && client.respond_to?(:port)
         "Client: #{client.host}:#{client.port}"
       else

--- a/radar_client_rb.gemspec
+++ b/radar_client_rb.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "radar_client_rb", Radar::Client::VERSION do |gem|
 
   gem.required_ruby_version = ["~> 2.2", ">= 2.2"]
 
-  gem.add_runtime_dependency("redis", "~> 3.3")
+  gem.add_runtime_dependency("redis", "~> 4.3")
 
   gem.add_development_dependency("rake")
   gem.add_development_dependency("minitest")


### PR DESCRIPTION
### Description

Bringing radar_client_rb up to current version of redis client driver v4.3.1, replacing deprecated `client` object with `connection` which returns a hash of the connection details in redis v4.x

https://github.com/redis/redis-rb/blob/master/CHANGELOG.md

### Risks
- Low: Will bump the library as a new major version as to not break any existing gemfile references that consume any radar_client_rb versions 2.x from rubygems.org

### Rollback
- Revert commit and merge to master, no changes required to consumers.
