### PR TITLE
Add ruby 3 to testing matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,6 +4,11 @@ jobs:
   main:
     name: Test with Ruby ${{ matrix.ruby-version }}
     runs-on: ubuntu-20.04
+    services:
+      redis:
+        image: redis:7.0.5
+        ports:
+          - 6379:6379
     strategy:
       matrix:
         ruby-version:
@@ -18,3 +23,5 @@ jobs:
           bundler-cache: true
       - name: rake test
         run: bundle exec rake test
+        env:
+          REDIS_URL: 'redis://localhost:6379'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,21 +2,19 @@ name: CI
 on: [push]
 jobs:
   main:
-    name: rake test
-    runs-on: ubuntu-18.04
+    name: Test with Ruby ${{ matrix.ruby-version }}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rvm:
-          - 2.6
-          - 2.7
+        ruby-version:
+          - "2.6"
+          - "2.7"
+          - "3.2"
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - uses: zendesk/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.rvm }}
-      - name: install
-        run: |
-          gem install bundler -v 1.17.2
-          bundle install
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
       - name: rake test
         run: bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,4 +27,4 @@ DEPENDENCIES
   rake (>= 12.3.3)
 
 BUNDLED WITH
-   1.17.3
+   2.3.20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     bump (0.10.0)
-    fakeredis (0.8.0)
-      redis (~> 4.1)
     minitest (5.14.4)
     mocha (1.13.0)
     rake (13.0.6)
@@ -20,7 +18,6 @@ PLATFORMS
 
 DEPENDENCIES
   bump
-  fakeredis
   minitest
   mocha
   radar_client_rb!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     bump (0.10.0)
-    minitest (5.14.4)
-    mocha (1.13.0)
+    minitest (5.17.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     rake (13.0.6)
-    redis (4.3.1)
+    redis (4.8.1)
+    ruby2_keywords (0.0.5)
 
 PLATFORMS
   ruby

--- a/radar_client_rb.gemspec
+++ b/radar_client_rb.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new "radar_client_rb", Radar::Client::VERSION do |gem|
   gem.summary = gem.description = "Read/Write Radar Resources from Redis through Ruby"
   gem.files = Dir.glob("lib/**/*")
 
-  gem.required_ruby_version = ["~> 2.6", ">= 2.6"]
+  gem.required_ruby_version = ">= 2.6"
 
   gem.add_runtime_dependency("redis", "~> 4.3")
 

--- a/radar_client_rb.gemspec
+++ b/radar_client_rb.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new "radar_client_rb", Radar::Client::VERSION do |gem|
 
   gem.add_development_dependency("rake", ">=12.3.3")
   gem.add_development_dependency("minitest")
-  gem.add_development_dependency("fakeredis")
   gem.add_development_dependency("mocha")
   gem.add_development_dependency("bump")
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -220,8 +220,8 @@ describe Radar::Client do
     it 'can retrieve a status' do
       assert_equal client.status(scope).get(user_id1), status1
       assert_equal client.status(scope).get(user_id2), status2
-      assert_equal client.status(scope).get(user_id4), nil
-      assert_equal client.status('inexistant').get('non-key'), nil
+      assert_nil client.status(scope).get(user_id4)
+      assert_nil client.status('inexistant').get('non-key')
     end
 
     it 'can set a status' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'radar_client_rb'
 require 'redis'
-require 'mocha/setup'
+require 'mocha/minitest'
 
 describe Radar::Client do
   let(:user_id1) { 123 }


### PR DESCRIPTION
### Description

- Add Ruby 3 to the testing matrix.
- Remove the development dependency on fakeredis (abandonware).

### Risks
- Low: Ruby 3 testing

### Rollback

