### PR TITLE
Add gem release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish Gem
+
+on:
+  push:
+    tags: v*
+
+    jobs:
+      call-workflow:
+        uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+        secrets:
+          RUBY_GEMS_API_KEY: { secrets.RUBY_GEMS_API_KEY }
+          RUBY_GEMS_TOTP_DEVICE: { secrets.RUBY_GEMS_TOTP_DEVICE }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    radar_client_rb (3.0.0)
+    radar_client_rb (3.1.0)
       redis (~> 4.3)
 
 GEM

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@ require 'bundler/setup'
 require 'bump/tasks'
 require 'bundler/gem_tasks'
 
+# Pushing to rubygems is handled by a github workflow
+ENV['gem_push'] = 'false'
+
 task :default => [:test]
 
 Dir.glob('./tasks/*.rake').each { |r| import r }

--- a/lib/radar_client_rb/version.rb
+++ b/lib/radar_client_rb/version.rb
@@ -1,5 +1,5 @@
 module Radar
   class Client
-    VERSION = '3.0.0'
+    VERSION = '3.1.0'
   end
 end


### PR DESCRIPTION
Creates a workflow for publishing to Zendesk’s public RubyGems account.

Uses the workflow from the public `gw` gem. `gw`'s [ruby-gem-publication readme](https://github.com/zendesk/gw/blob/main/ruby-gem-publication/README.md)

In order to publish a new version of this gem, you commit a change to the version.rb file (and Gemfile.lock, please), and run `rake release`. Then you get someone to approve the "publish" job in https://github.com/zendesk/radar_client_rb/actions/workflows/publish.yml